### PR TITLE
Makefile adjustment fix#39

### DIFF
--- a/source/makefile
+++ b/source/makefile
@@ -22,7 +22,8 @@ endif
 
 # updating some commands if system is windows
 ifeq ($(SYS),WIN)
-        OS_FLAG = -DWIN64=1
+	SHELL=cmd.exe
+	OS_FLAG = -DWIN64=1
 	MKDIR = mkdir
 	RM = del /Q
 	RMDIR = rmdir /Q /S

--- a/source/makefile
+++ b/source/makefile
@@ -4,10 +4,12 @@ CC = gfortran
 OPTIMIZE ?= -O3
 MODELNAME ?= APM-MODEL.EXE
 OBJDIR ?= dist
-OS = -DWIN64=0
+OS_FLAG = -DWIN64=0
 MKDIR = mkdir -p 
 RM = rm -f
 RMDIR = rm -rf
+
+override OBJDIR := $(strip $(OBJDIR))/
 
 # determining system type if not supplied
 ifdef SystemRoot
@@ -20,13 +22,10 @@ endif
 
 # updating some commands if system is windows
 ifeq ($(SYS),WIN)
-        OS = -DWIN64=1
-	override OBJDIR := $(strip $(OBJDIR))\\
+        OS_FLAG = -DWIN64=1
 	MKDIR = mkdir
 	RM = del /Q
 	RMDIR = rmdir /Q /S
-else
-	override OBJDIR := $(strip $(OBJDIR))/
 endif
 
 # setting default goal after setting object directory
@@ -49,14 +48,14 @@ MODULE_OBJS = $(addprefix $(OBJDIR), $(MODULE_FILES:.F=.o))
 #
 # determining flags to apply at compile time based on target
 # test flags are only defined when this file is included into the testing makefile
-FLAGS = $(OPTIMIZE) $(OS) -J$(OBJDIR)
+FLAGS = $(OPTIMIZE) $(OS_FLAG) -J$(OBJDIR)
 debug test: FLAGS = -fimplicit-none -fwhole-file -fcheck=all -std=f2008 -pedantic -fbacktrace -cpp -g -pg
 debug test: FLAGS += -Wall -Wline-truncation -Wcharacter-truncation -Wsurprising -Waliasing -Wunused-parameter
-debug test: FLAGS += $(OS) -J$(OBJDIR) -I$(OBJDIR)
+debug test: FLAGS += $(OS_FLAG) -J$(OBJDIR) -I$(OBJDIR)
 
 
 ${OBJDIR}:
-	$(MKDIR) $(OBJDIR)
+	$(MKDIR) $(OBJDIR:/=)
 
 ${OBJDIR}%.o : %.F | ${OBJDIR}
 	$(CC) -c $(FLAGS) $(TEST_FLAGS) -o $@ $<
@@ -68,4 +67,4 @@ debug: clean ${OBJDIR}${MODELNAME}
 
 clean:
 	$(RM) *.o *.mod *.EXE *.gcno *.gcda *.gcov
-	$(RMDIR) $(OBJDIR)
+	$(RMDIR) $(OBJDIR:/=)

--- a/source/makefile
+++ b/source/makefile
@@ -1,24 +1,39 @@
 #
-# defining variables
+# defining default variable names (assume POISX system)
 CC = gfortran
 OPTIMIZE ?= -O3
 MODELNAME ?= APM-MODEL.EXE
-OBJDIR = dist/
-RM = rm -rf
-MKDIR = mkdir -p $(OBJDIR)
-.DEFAULT_GOAL:= $(OBJDIR)$(MODELNAME)
-
-# setting OS flag
+OBJDIR ?= dist
 OS = -DWIN64=0
+MKDIR = mkdir -p 
+RM = rm -f
+RMDIR = rm -rf
+
+# determining system type if not supplied
 ifdef SystemRoot
-	OS = -DWIN64=1
-	MKDIR = echo "Manually create source/dist directory if needed"
+	SYS ?=WIN
 else ifdef SYSTEMROOT
-	OS = -DWIN64=1
-	MKDIR = echo "Manually create source/dist directory if needed"
+	SYS ?=WIN
+else
+	SYS ?=POSIX
 endif
 
-# setting variables
+# updating some commands if system is windows
+ifeq ($(SYS),WIN)
+        OS = -DWIN64=1
+	override OBJDIR := $(strip $(OBJDIR))\\
+	MKDIR = mkdir
+	RM = del /Q
+	RMDIR = rmdir /Q /S
+else
+	override OBJDIR := $(strip $(OBJDIR))/
+endif
+
+# setting default goal after setting object directory
+.DEFAULT_GOAL:= $(OBJDIR)$(MODELNAME)
+
+
+# setting up object variables
 MODEL_FILES := $(wildcard *.F)
 MODEL_OBJS = $(addprefix $(OBJDIR), $(MODEL_FILES:.F=.o))
 
@@ -41,7 +56,7 @@ debug test: FLAGS += $(OS) -J$(OBJDIR) -I$(OBJDIR)
 
 
 ${OBJDIR}:
-	$(MKDIR)
+	$(MKDIR) $(OBJDIR)
 
 ${OBJDIR}%.o : %.F | ${OBJDIR}
 	$(CC) -c $(FLAGS) $(TEST_FLAGS) -o $@ $<
@@ -52,4 +67,5 @@ ${OBJDIR}${MODELNAME}: ${MODULE_OBJS} ${MODEL_OBJS}
 debug: clean ${OBJDIR}${MODELNAME}
 
 clean:
-	$(RM) $(OBJDIR) *.o *.mod *.EXE *.gcno *.gcda *.gcov
+	$(RM) *.o *.mod *.EXE *.gcno *.gcda *.gcov
+	$(RMDIR) $(OBJDIR)

--- a/source/makefile
+++ b/source/makefile
@@ -5,19 +5,24 @@ OPTIMIZE ?= -O3
 MODELNAME ?= APM-MODEL.EXE
 OBJDIR ?= dist
 OS_FLAG = -DWIN64=0
-MKDIR = mkdir -p 
+MKDIR = mkdir -p
 RM = rm -f
 RMDIR = rm -rf
+OS_NAME =$(shell uname)
 
 override OBJDIR := $(strip $(OBJDIR))/
 
 # determining system type if not supplied
-ifdef SystemRoot
-	SYS ?=WIN
-else ifdef SYSTEMROOT
-	SYS ?=WIN
-else
-	SYS ?=POSIX
+ifndef SYS
+	ifneq (,$(findstring CYGWIN,$(OS_NAME)))
+		SYS = POSIX
+	else ifdef SystemRoot
+		SYS = WIN
+	else ifdef SYSTEMROOT
+		SYS = WIN
+	else
+		SYS = POSIX
+	endif
 endif
 
 # updating some commands if system is windows
@@ -56,7 +61,7 @@ debug test: FLAGS += $(OS_FLAG) -J$(OBJDIR) -I$(OBJDIR)
 
 
 ${OBJDIR}:
-	$(MKDIR) $(OBJDIR:/=)
+	-$(MKDIR) $(OBJDIR:/=)
 
 ${OBJDIR}%.o : %.F | ${OBJDIR}
 	$(CC) -c $(FLAGS) $(TEST_FLAGS) -o $@ $<
@@ -68,4 +73,4 @@ debug: clean ${OBJDIR}${MODELNAME}
 
 clean:
 	$(RM) *.o *.mod *.EXE *.gcno *.gcda *.gcov
-	$(RMDIR) $(OBJDIR:/=)
+	-$(RMDIR) $(OBJDIR:/=)


### PR DESCRIPTION
Fix #39 

Adds logic to be more friendly to windows builds. `make clean` and `make debug` will now work on Windows. Additionally it will try to detect being run in a Cygwin environment (i.e. Babun) and then allow normal POSIX behavoir and commands