### PR TITLE
Remove use if imp module and fix exc_clear error

### DIFF
--- a/test/unit/TestCore.py
+++ b/test/unit/TestCore.py
@@ -8,7 +8,7 @@ Last Modifed: 2017/02/12
 """
 from argparse import Namespace
 from collections import namedtuple
-from imp import reload
+from importlib import reload
 import logging
 import os
 import pytest
@@ -34,7 +34,7 @@ class TestCore:
         """
         version = namedtuple('version', ['major', 'minor', 'micro', 'releaselevel', 'serial'])
         orig_version = sys.version_info
-        test_vers = version(major=2, minor=7, micro=5, releaselevel='final', serial='')
+        test_vers = version(major=3, minor=0, micro=0, releaselevel='final', serial='')
         #
         monkeypatch.setattr(sys, 'version_info', test_vers)
         with pytest.raises(Exception):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 codecov
 coverage
 pep8
-pytest==3.0.3
+pytest
 pytest-cache
 pytest-cov
 pytest-pep8


### PR DESCRIPTION
Fix #44 

importlib has now been used in place of imp in TestCore.py (the only place it was used)

Fix the mysterious exc_clear error in pytest.raises, as such I have removed the pytest version restriction.

Turns out my version spoofing to test imports was actually causing
an unforeseen bug deep in the pytest.raises context manager. When it
detected Python 2 (from the spoof) it thought sys.exc_clear actually existed.