### PR TITLE
Stadelmanma update readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ Linux
     A. In a terminal, copy and paste the command :code:`bash ~/Downloads/Anaconda3-4.2.0-Linux-x86_64.sh` you may need to tweak the path and or filename if a new version of Anaconda is released. 
     B. Follow the instructions as the installation script runs and enter 'yes' when it prompts to update your :code:`$PATH` variable.
         * If using a different shell (i.e. zsh) you will likely need to manually update your :code:`$PATH` variable.
-    C. Close your existing terminal window and open a new one, enter :code:`python --version` to check if Anaconda has installed Python successfully.
+    C. Close your existing terminal window and open a new one, enter :code:`python3 --version` to check if Anaconda has installed Python successfully.
 3. Install :code:`gfortran` using the terminal command :code:`sudo apt-get install gfortran`.
     A. Run :code:`gfortran --version` in a new terminal window to check if it was installed properly.
 4. Open a terminal or cd into the directory you want to install the AP_MAP_FLOW package in.
     A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`.
     B. Run the command :code:`cd netl-AP_MAP_FLOW`.
-    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 user site.'    
+    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 installation.
 
 MacOS/ OSX
 ~~~~~~~~~~
@@ -77,7 +77,7 @@ MacOS/ OSX
 4. Open a terminal and cd into the directory you want to install the AP_MAP_FLOW package in
     A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`
     B. Run the command :code:`cd netl-AP_MAP_FLOW`
-    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 user site
+    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 installation.
 
 Windows
 ~~~~~~~
@@ -105,7 +105,6 @@ Windows with Babun
     A. Run :code:`nano ~/.zshrc` to edit the file and copy and paste the .zshrc code block below into the bottom of the file. 
         * Make sure you used the down arrow key to put your cursor at the bottom of the file
         * Once you've copied the block all you have to do in Babun is right click to paste, if you accidently highlighted something in Babun before pasting you will need to copy the block again.
-        * In Babun :code:`/cygdrive/c/` takes the place of the drive letter i.e. :code:`C:` and be sure you use forward slashes instead of back slashes. 
         * If you installed Anaconda somewhere else you will need to tweak the path to match.
     B. Hit Ctrl+O and then Enter to save the file and then Ctrl+X to exit nano.
     C. Run :code:`source ~/.zshrc` to reload everything and try to start Python by running :code:`python3`
@@ -119,7 +118,7 @@ Windows with Babun
     C. Run the command :code:`dos2unix ./bin/*`
         * This converts Windows line endings :code:`\r\n` into unix line endings :code:`\n`
     C. Run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools package Anaconda's Python3
-    D. Run :code:`./bin/create-script-runners` to allow usage of the apm\_\* scripts in the scripts directory within babun. 
+    D. Run :code:`./bin/create-script-runners` to allow usage of the files in the ./scripts directory within babun. 
         * Run :code:`source ~/.zshrc` or open a new Babun terminal so it registers the changes
         * To execute one of the runner scripts simply type :code:`apm_` and then hit tab to cycle through the options. Use :code:`(script name) -h` for usage information.
         * If you move the netl-Ap_MAP_FLOW directory you will need to re-run the command to update the runners

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,16 @@ Setting up the Modeling Package
 -------------------------------
 These steps were followed on Ubuntu 14.04 & 16.04, OSX 10.9 & MacOS 10.12 and Windows 7. They are not guaranteed to remain updated however the general process should be relatively stable as all dependencies are being handled by large, community driven projects i.e. Anaconda, MinGW, GCC, etc. Running the test suite in Windows is possible but not without some manual adjustments and extra effort. 
 
-An extra step that may prevent unexpected errors would be to run :code:`sudo conda update --all` or :code:`sudo pip install -r requirements.txt --upgrade` after the final step especially if you are using an existing Anaconda install.
+Installation Tips
+~~~~~~~~~~~~~~~~~
+* Anaconda's full installation instructions for all OSes can be found here: https://docs.continuum.io/anaconda/install
+* This guide assumes you install Anaconda3 locally. If you choose to install it system wide you will need to run some commands with :code:`sudo` in unix systems or in an elevated command prompt in Windows.
+* For unix systems that already have a system version of Python 2.7, :code:`python` will likely also bring up the Anaconda version, to regain access to the system version of Python delete the :code:`python` symlink in :code:`~/anaconda/bin`
+* After installing Anaconda3 run :code:`pip --version` in a terminal to ensure it points to the anaconda installation, if not check your PATH.
+* After downloading the model run :code:`conda update --all` and :code:`pip install -r requirements.txt --upgrade` to ensure all packages are up to date. 
+* Run :code:`pip install -r test_requirements.txt` to enable running the test suite.
+* When running the test suite, recompile the model using :code:`./bin/build_model debug` which builds the model using additional flags, code coverage and profiling
+* After installation run the script :code:`./bin/create-script-runners [directory]` to make model scripts accessible on the PATH, this will not work in regular Windows cmd.exe (use Babun or Cygwin). If :code:`[directory]` is not supplied it will try to place them in :code:`~/.local/bin`
 
 Linux
 ~~~~~
@@ -42,60 +51,91 @@ Linux
     A. Run :code:`git --version` in a new terminal window to check if it was installed properly.
 2. Download and Install the 64 bit, Python 3.X version of  `Anaconda <https://www.continuum.io/downloads#linux>`_ for Linux.
     A. In a terminal, copy and paste the command :code:`bash ~/Downloads/Anaconda3-4.2.0-Linux-x86_64.sh` you may need to tweak the path and or filename if a new version of Anaconda is released. 
-    B. Follow the instructions as the installation script runs and enter 'yes' when it prompts to update your :code:`$PATH` variable. 
+    B. Follow the instructions as the installation script runs and enter 'yes' when it prompts to update your :code:`$PATH` variable.
         * If using a different shell (i.e. zsh) you will likely need to manually update your :code:`$PATH` variable.
     C. Close your existing terminal window and open a new one, enter :code:`python --version` to check if Anaconda has installed Python successfully.
-    D. Anaconda's full installation instructions can be found here: https://docs.continuum.io/anaconda/install#linux-install
 3. Install :code:`gfortran` using the terminal command :code:`sudo apt-get install gfortran`.
     A. Run :code:`gfortran --version` in a new terminal window to check if it was installed properly.
 4. Open a terminal or cd into the directory you want to install the AP_MAP_FLOW package in.
     A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`.
     B. Run the command :code:`cd netl-AP_MAP_FLOW`.
-    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 user site.
-    D. Optional: run :code:`pip install -r test_requirements.txt` to enable running the test suite.
-        * When running the test suite, recompile the model using :code:`./bin/build_model debug` which builds the model using additional flags and code coverage
+    C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 user site.'    
 
 MacOS/ OSX
 ~~~~~~~~~~
 1. Install Xcode from the App Store
-    A. Open Xcode once it is install and allow it to install additional components, this includes the Command Line Tools (CLT)
+    A. Open Xcode once it is installed and allow it to install additional components, this includes the Command Line Tools (CLT)
 2. Install `homebrew <http://brew.sh>`_
     A. After installation :code:`brew install gcc` to install gfortran and many other useful tools
         * It may take awhile on the :code:`make bootstrap` step, my complete installation took approximately 90 minutes.
 3. Download and install the 64 bit, Python 3.X version of `Anaconda <https://www.continuum.io/downloads#osx>`_ for MacOS
     A. Choose the "Install for Me Only" option when prompted
-    B. Open or create the ~/.bashrc (or equivalent for your shell i.e. ~/.zshrc) file and preappend :code:`$HOME/anaconda/bin:` to the :code:`$PATH` variable. 
-        * If you need to create the ~/.bashrc file or there is no $PATH line in the file, the following line should work: :code:`export PATH=$HOME/anaconda/bin:$PATH`
-        * Be careful not to forget the :code:`:` between directory paths or to export the PATH variable i.e. :code:`export $PATH`. 
+    B. Open or create the ~/.bashrc (or equivalent for your shell i.e. ~/.zshrc) file and add the line :code:`export PATH=$HOME/anaconda/bin:$PATH`.
+        * Be careful not to forget the :code:`:` between directory paths 
         * If you edited the ~/.bashrc file in the terminal or have an open window run :code:`source ~/.bashrc` to apply changes, alternatively close and open a term terminal window. 
-    C. In a terminal window run :code:`python3 --version` to ensure Anaconda was installed properly
-        * :code:`python` will likely also bring up the Anaconda version of 3.5, to regain access to the system version of Python delete the :code:`python` symlink in :code:`~/anaconda/bin`
-    B. Anaconda's full installation instructions can be found here: https://docs.continuum.io/anaconda/install#anaconda-for-os-x-graphical-install
-4. Open a terminal or cd into the directory you want to install the AP_MAP_FLOW package in
+    C. In a terminal window run :code:`python3 --version` to ensure Anaconda was installed properly and is accessible
+4. Open a terminal and cd into the directory you want to install the AP_MAP_FLOW package in
     A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`
     B. Run the command :code:`cd netl-AP_MAP_FLOW`
     C. Finally run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools module to the python3 user site
-    D. Optional: run :code:`pip install -r test_requirements.txt` to enable running the test suite.
-        * When running the test suite, recompile the model using :code:`./bin/build_model debug` which builds the model using additional flags and code coverage
 
 Windows
 ~~~~~~~
 1. Download and install the 64 bit, Python 3.X version of `Anaconda <https://www.continuum.io/downloads#windows>`_ for Windows
     A. Open a command prompt (it's under Accessories) and enter :code:`python`. If the installion was successful the interpreter will be displayed
     B. Exit the Python interpreter hit :code:`Ctrl+Z` and then :code:`Enter` 
-    C. Run the command :code:`conda install git`, you may need an elevated command prompt depending on where Anaconda was installed. Right click the command prompt icon on the start menu and select :code:`Run as Administrator`
-    D. Anaconda's full installation instructions can be found here: https://docs.continuum.io/anaconda/install#anaconda-for-windows-install
+    C. Run the command :code:`conda install git`
 2. Download and install `MinGW-w64 <https://sourceforge.net/projects/mingw-w64/>`_ for windows
     A. Double click the installation script that was downloaded and hit :code:`Next`
     B. Change the value of the Architecture select box to :code:`x86_64` and hit :code:`Next`
-    C. Modify the installation path to be: :code:`C:\Program Files\mingw-w64`, untick the :code:`create shortcuts` box and hit :code:`next`
+    C. Modify the installation path to be: :code:`C:\mingw-w64`, untick the :code:`create shortcuts` box and hit :code:`next`
     D. Wait for the packages to finish downloading and hit :code:`Next` and then :code:`Finish`
-    E. Go to the folder :code:`C:\Program Files\mingw-w64\mingw64\bin` and rename (or duplicate) the file :code:`mingw32-make.exe` as :code:`make.exe`
-    F. Finally add the path :code:`C:\Program Files\mingw-w64\mingw64\bin` to the `Windows environment Path <http://stackoverflow.com/a/28545224>`_.
+    E. Go to the folder :code:`C:\mingw-w64\mingw64\bin` and rename (or duplicate) the file :code:`mingw32-make.exe` as :code:`make.exe`
+    F. Finally add the path :code:`C:\mingw-w64\mingw64\bin` to the `Windows environment Path <http://stackoverflow.com/a/28545224>`_.
 3. Shift + right click in the directory you want to install the AP_MAP_FLOW package and open a command window.
     A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`
     B. Run the command :code:`cd netl-AP_MAP_FLOW`
     C. Finally run :code:`.\bin\build_model.bat` which will build the model and link the ApertureMapModelTools package to the installed version of python
+
+Windows with Babun
+~~~~~~~~~~~~~~~~~~
+`Babun <http://babun.github.io/>`_ offers a much friendlier terminal experience than the standard cmd.exe prompt. To use the code with Babun follow steps 1 and 2 for regular Windows installation using the cmd.exe prompt and then download and install Babun.
+
+1. Open up a Babun prompt using the start menu. 
+    A. Run :code:`nano ~/.zshrc` to edit the file and copy and paste the .zshrc code block below into the bottom of the file. 
+        * Make sure you used the down arrow key to put your cursor at the bottom of the file
+        * Once you've copied the block all you have to do in Babun is right click to paste, if you accidently highlighted something in Babun before pasting you will need to copy the block again.
+        * In Babun :code:`/cygdrive/c/` takes the place of the drive letter i.e. :code:`C:` and be sure you use forward slashes instead of back slashes. 
+        * If you installed Anaconda somewhere else you will need to tweak the path to match.
+    B. Hit Ctrl+O and then Enter to save the file and then Ctrl+X to exit nano.
+    C. Run :code:`source ~/.zshrc` to reload everything and try to start Python by running :code:`python3`
+        * Exit Anaconda Python3 in Babun using **Ctrl+C** instead of Ctrl+Z or Ctrl+D
+2. Run this command in the Babun prompt :code:`ln -s "/cygdrive/c/Users/$USER/Anaconda3/python.exe" "/usr/local/bin/python3"`
+    * This allows the module to be linked properly in step 3.
+    * As before you will need to tweak the path if you installed Anaconda somewhere else
+3. Open a Babun prompt in the same directory that you want to install the modeling package in by right clicking in the folder explorer window or on the Desktop if that is your chosen location.
+    A. Run the command :code:`git clone https://github.com/stadelmanma/netl-AP_MAP_FLOW.git`
+    B. Run the command :code:`cd netl-AP_MAP_FLOW`
+    C. Run the command :code:`dos2unix ./bin/*`
+        * This converts Windows line endings :code:`\r\n` into unix line endings :code:`\n`
+    C. Run :code:`./bin/build_model` which will build the model and link the ApertureMapModelTools package Anaconda's Python3
+    D. Run :code:`./bin/create-script-runners` to allow usage of the apm\_\* scripts in the scripts directory within babun. 
+        * Run :code:`source ~/.zshrc` or open a new Babun terminal so it registers the changes
+        * To execute one of the runner scripts simply type :code:`apm_` and then hit tab to cycle through the options. Use :code:`(script name) -h` for usage information.
+        * If you move the netl-Ap_MAP_FLOW directory you will need to re-run the command to update the runners
+
+.. code-block:: shell
+
+    # Babun ~/.zshrc code block
+    # Append Anaconda directories to override python 2.7 in /usr/bin/
+    PATH="/cygdrive/c/Users/$USER/Anaconda3/:$PATH"
+    PATH="/cygdrive/c/Users/$USER/Anaconda3/Scripts:$PATH"
+    PATH="/cygdrive/c/Users/$USER/Anaconda3/Library/bin:$PATH"
+    export PATH
+    #
+    # alias python3 to work interactively and pytho back to regular babun version
+    alias python="/usr/bin/python"
+    alias python3="/cygdrive/c/Users/$USER/Anaconda3/python.exe -i"
 
 Basic Usage of APM Model
 ------------------------

--- a/examples/running-the-flow-model.rst
+++ b/examples/running-the-flow-model.rst
@@ -14,7 +14,7 @@ The Local Cubic Law (LCL) flow model by default is named :code:`APM-MODEL.EXE`, 
 The Input Parameters File
 =========================
 
-A template of the input parameters file can be found in `here <apm-model-inputs-template.inp>`_. The input file is parsed by a special routine in the model that treats all text after a semicolon, :code:`;`, as comments and one or more spaces as delimiters. A value enclosed in double quotations will have any internal spaces ignored. ApertureMapModelTools also reads the input files when needed and for consistency it is recommended you append a colon :code:`:` onto the end of keywords. Nearly all of the input parameters have default values and they are defined in `APM_SUBROUTINES.F <../source/APM_SUBROUTINES.F>`_ in the first subroutine :code:`INITIALIZE_RUN`
+A template of the input parameters file can be found in `here <apm-model-inputs-template.inp>`_. The input file is parsed by a special routine in the model that treats all text after a semicolon, :code:`;`, as comments and one or more spaces as delimiters. A value enclosed in double quotations will have any internal spaces ignored. ApertureMapModelTools also reads the input files when needed and for consistency it is recommended you append a colon :code:`:` onto the end of keywords. Nearly all of the input parameters have default values and they are defined in `APERTURE_MAP_FLOW.F <../source/APERTURE_MAP_FLOW.F>`_ in the subroutine :code:`INITIALIZE_RUN`
 
 **Important Notes**
  * There must be at least one space separating keyword and value.
@@ -61,22 +61,16 @@ Defines the boundary conditions for the model, the model does no internal checki
 
 Model Properties
 ----------------
-
-Sets various fluid and model properties.
-
  * :code:`FLUID-DENSITY:` value unit ;Density of liquid to use in Reynolds number calculation
  * :code:`FLUID-VISCOSITY:` value unit ;Viscosity of liquid
- * :code:`MAXIMUM MAP DIMENSION:` value ;Maximum number of blocks along either axis. Values close to actual axis size slightly improve runtime memory conservation relative to much larger values.
+ * :code:`MAXIMUM MAP DIMENSION:` value ;Maximum number of blocks along either axis (default 2000)
 
 Other Parameters
 ----------------
-
-Sets other important miscellaneous runtime parameters.
-
  * :code:`MAP AVERAGING FACTOR:` value ;The number of voxels required to span an edge of a grid block along the X or Z direction. Grid blocks are assumed square in the X-Z plane.
  * :code:`VOXEL SIZE:` value unit ;Specifies the voxel to meter conversion factor
  * :code:`ROUGHNESS REDUCTION:` value ;**The value is in voxels** Amount to symmetrically bring the front and back fracture surfaces together by.
- * :code:`CALCULATE PERCENTILES:` value1,value2,value3 ;A comma separated list of percentiles to calculate of various quantities during runtime. Commenting this line out tells it to not calculate them at all
+ * :code:`CALCULATE PERCENTILES:` value1,value2,value3 ;A comma separated list of percentiles to calculate for various quantities during runtime. Commenting this line out tells it to not calculate them at all
  * :code:`HIGH-MASK:` value ;**The value is in voxels** All data values in the aperture map above this value will be reduced to this value.
  * :code:`LOW-MASK:` value ;**The value is in voxels** All data values in the aperture map below this value will be raised to this value
 
@@ -96,7 +90,7 @@ Before we actually run the model it will be helpful to have a place to store the
     cd model-testing
     touch model-input-params.inp
 
-Open model-input-params.inp with your favorite text editor and copy and paste the following block. Notice most of the inputs are **not** preceded by a semicolon here like they were in the blank file above.
+Open model-input-params.inp with your favorite text editor and copy and paste the following block. 
 
 .. code-block:: Scheme
 
@@ -265,7 +259,7 @@ The run_model Function
 The run_model function combines some higher level Python functionality for working with the system shell into a simple package. The model can be both run synchronously or asynchronously but in both cases it returns a `Popen <https://docs.python.org/3/library/subprocess.html#subprocess.Popen>`_ object. Running the model synchronously can take a long time when running large aperture maps.
 
 Argument - Type - Description
- * input_file_obj - InputFile - the input file object run with the model. Note: This file has to be written be careful to not overwrite existing files by accident
+ * input_file_obj - InputFile - the input file object run with the model. Note: This file has to be written to disk, be careful to not overwrite existing files by accident
  * synchronous - boolean - If True the function will halt execution of the script until the model finishes running. The default is False.
  * show_stdout - boolean - If True then stdout and stderr will be printed to the screen instead of being stored on the Popen object as stdout_content and stderr_content
 


### PR DESCRIPTION
Fixes  #54 

Cleans up installation steps, adds a set of tips that may prove useful and adds a section dedicated to usage with Babun. Although it should work for regular Cygwin as well.

Also did some minor tweaks to the running-the-model readme